### PR TITLE
Remove the PYTHONEXECUTABLE variable from nushell scripts

### DIFF
--- a/src/virtualenv/activation/nushell/activate.nu
+++ b/src/virtualenv/activation/nushell/activate.nu
@@ -8,15 +8,12 @@ let old-path = ($nu.path | str collect ($path-sep))
 let venv-path = ([$virtual-env $bin] | path join)
 let new-path = ($nu.path | prepend $venv-path | str collect ($path-sep))
 
-let python_executable = ([$virtual-env $bin "python.exe"] | path join)
-
 # environment variables that will be batched loaded to the virtual env
 let new-env = ([
     [name, value];
     [PATH $new-path]
     [_OLD_VIRTUAL_PATH $old-path]
     [VIRTUAL_ENV $virtual-env]
-    [PYTHONEXECUTABLE $python_executable]
 ])
 
 load-env $new-env

--- a/src/virtualenv/activation/nushell/deactivate.nu
+++ b/src/virtualenv/activation/nushell/deactivate.nu
@@ -6,7 +6,6 @@ let-env $path-name = $nu.env._OLD_VIRTUAL_PATH
 unlet-env VIRTUAL_ENV
 unlet-env _OLD_VIRTUAL_PATH
 unlet-env PROMPT_STRING
-unlet-env PYTHONEXECUTABLE
 
 unalias pydoc
 unalias deactivate


### PR DESCRIPTION
PYTHONEXECUTABLE is not used by any of the other shell activation scripts,
setting it directly will require this script to walk the path and determine the
OS. We should not be setting it. This resolves test failures on macOS, since the
previous version added the windows-specific `.exe` suffix.

### Thanks for contributing, make sure you address all the checklists (for details on how see
[development documentation](https://virtualenv.pypa.io/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (``tox -e fix_lint``)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in ``docs/changelog`` folder
- [ ] updated/extended the documentation
